### PR TITLE
Hotfix: set text color to white in snake page styles

### DIFF
--- a/frontend/src/app/pages/snake/snake.scss
+++ b/frontend/src/app/pages/snake/snake.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: first baseline;
   padding: 20px;
+  color: #fff;
   background-color: #2c0d24;
 }
 


### PR DESCRIPTION
Added 'color: #fff;' to the .snake-page class in snake.scss to ensure text is displayed in white, improving readability.